### PR TITLE
updated references to deprecated policy/v1beta1 with policy/v1; re: issue #63

### DIFF
--- a/controllers/valhalla_controller.go
+++ b/controllers/valhalla_controller.go
@@ -29,7 +29,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -402,6 +402,6 @@ func (r *ValhallaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&autoscalingv1.HorizontalPodAutoscaler{}).
-		Owns(&policyv1beta1.PodDisruptionBudget{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
 		Complete(r)
 }

--- a/internal/resource/pod_disruption_budget.go
+++ b/internal/resource/pod_disruption_budget.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/itayankri/valhalla-operator/internal/status"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +20,7 @@ func (builder *ValhallaResourceBuilder) PodDisruptionBudget() *PodDisruptionBudg
 }
 
 func (builder *PodDisruptionBudgetBuilder) Build() (client.Object, error) {
-	return &policyv1beta1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      builder.Instance.ChildResourceName(HorizontalPodAutoscalerSuffix),
 			Namespace: builder.Instance.Namespace,
@@ -30,7 +30,7 @@ func (builder *PodDisruptionBudgetBuilder) Build() (client.Object, error) {
 
 func (builder *PodDisruptionBudgetBuilder) Update(object client.Object) error {
 	name := builder.Instance.ChildResourceName(PodDisruptionBudgetSuffix)
-	pdb := object.(*policyv1beta1.PodDisruptionBudget)
+	pdb := object.(*policyv1.PodDisruptionBudget)
 
 	pdb.Spec.MinAvailable = builder.Instance.Spec.GetMinAvailable()
 	pdb.Spec.Selector = &metav1.LabelSelector{


### PR DESCRIPTION
I've attempted to deploy this on GKE and am receiving errors about missing policies under policy/v1beta1, specifically with regard to the PodDisruptionBudget.

The `policy/v1beta1` API has been deprecated in v1.21 and since fully removed as of v1.25 in favour of the stable `policy/v1` API: https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-25#poddisruptionbudget-v125

I then found the issue https://github.com/itayankri/valhalla-operator/issues/63

I've replaced any occurrences of v1beta1 for the relevant policy with `v1` and built the project successfully, but I am not experienced with Go so I apologise if there are any issues introduced. 